### PR TITLE
Slight adjustments to invoice layout

### DIFF
--- a/app/views/spree/admin/orders/_invoice_table.html.haml
+++ b/app/views/spree/admin/orders/_invoice_table.html.haml
@@ -9,8 +9,9 @@
         %h5= @order.has_taxes_included ? t(:invoice_column_unit_price_with_taxes) : t(:invoice_column_unit_price_without_taxes)
       %th{:align => "right", :width => "15%"}
         %h5= @order.has_taxes_included ? t(:invoice_column_price_with_taxes) : t(:invoice_column_price_without_taxes)
-      %th{:align => "right", :width => "15%"}
-        %h5= @order.total_tax > 0 ? t(:invoice_column_tax_rate) : ""
+      - if @order.total_tax > 0
+        %th{:align => "right", :width => "15%"}
+          %h5= t(:invoice_column_tax_rate)
   %tbody
     - @order.line_items.sort_by{ |li| li.product.name }.each do |item|
       %tr
@@ -22,8 +23,9 @@
           = item.single_display_amount_with_adjustments
         %td{:align => "right"}
           = item.display_amount_with_adjustments
-        %td{:align => "right"}
-          = display_line_item_tax_rates(item)
+        - if @order.total_tax > 0
+          %td{:align => "right"}
+            = display_line_item_tax_rates(item)
     - checkout_adjustments_for(@order, exclude: [:line_item]).reject{ |a| a.amount == 0 }.reverse_each do |adjustment|
       %tr
         %td

--- a/app/views/spree/admin/orders/invoice.html.haml
+++ b/app/views/spree/admin/orders/invoice.html.haml
@@ -4,11 +4,14 @@
 %table{:width => "100%"}
   %tbody
     %tr{ valign: "top" }
-      %td{ :align => "left", colspan: 3 }
+      %td{ :align => "left" }
         %h4
           = t :tax_invoice
+      - if @order.distributor.display_invoice_logo? && @order.distributor.logo.present?
+        %td{ :align => "right", rowspan: 2 }
+          = wicked_pdf_image_tag @order.distributor.logo(:small), width: 150, height: 150
     %tr{ valign: "top" }
-      %td{ :align => "left", colspan: 2 }
+      %td{ :align => "left" }
         %strong= @order.distributor.name
         %br
         = @order.distributor.address.address_part1
@@ -25,21 +28,10 @@
         - if @order.distributor.acn.present?
           %br
           = "#{t :acn} #{@order.distributor.acn}"
-      - if @order.distributor.display_invoice_logo? && @order.distributor.logo.present?
-        %td{ :align => "right" }
-          = wicked_pdf_image_tag @order.distributor.logo(:small)
     %tr{ valign: "top" }
-      %td{ :align => "right", colspan: 3 }
-        %strong= @order.ship_address.full_name
-        - if @order.customer.code.present?
-          %br
-          = "Code: #{@order.customer.code}"
-        %br
-        = @order.ship_address.address_part1
-        %br
-        = @order.ship_address.address_part2
+      %td{ :align => "left", colspan: 2 } &nbsp;
     %tr{ valign: "top" }
-      %td{ :align => "left", colspan: 3 }
+      %td{ :align => "left" }
         = t :invoice_issued_on
         = l Time.zone.now.to_date
         %br
@@ -48,6 +40,15 @@
         %br
         = t :order_number
         = @order.number
+      %td{ :align => "right" }
+        %strong= @order.ship_address.full_name
+        - if @order.customer.code.present?
+          %br
+          = "Code: #{@order.customer.code}"
+        %br
+        = @order.ship_address.address_part1
+        %br
+        = @order.ship_address.address_part2
 
 = render 'spree/admin/orders/invoice_table'
 


### PR DESCRIPTION
1. Hide tax column when no tax included in the order
2. Save a little bit of space in the header by sharing rows