### PR TITLE
Adjust user signup feedback

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/authentication/login_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/authentication/login_controller.js.coffee
@@ -10,4 +10,4 @@ Darkswarm.controller "LoginCtrl", ($scope, $http, $window, AuthenticationService
         $window.location.href = $window.location.origin + $window.location.pathname  # Strips out hash fragments
     .error (data) ->
       Loading.clear()
-      $scope.errors = data.message
+      $scope.errors = data.message || data.error

--- a/app/controllers/user_registrations_controller.rb
+++ b/app/controllers/user_registrations_controller.rb
@@ -5,7 +5,7 @@ class UserRegistrationsController < Spree::UserRegistrationsController
   def create
     @user = build_resource(params[:spree_user])
     if resource.save
-      set_flash_message(:success, :signed_up)
+      set_flash_message(:success, :signed_up_but_unconfirmed)
       session[:spree_user_signup] = true
       associate_user
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,10 +67,14 @@ en:
             email:
               taken: "There's already an account for this email. Please login or reset your password."
   devise:
+    user_registrations:
+      spree_user:
+       signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please open the link to activate your account."
     failure:
       invalid: |
         Invalid email or password.
         Were you a guest last time?  Perhaps you need to create an account or reset your password.
+      unconfirmed: "You have to confirm your account before continuing."
     enterprise_confirmations:
       enterprise:
         confirmed: Thank you, your email address has been confirmed.


### PR DESCRIPTION
Fixes missing login modal messages and uses different feedback when registering to inform the user a confirmation email has been sent.